### PR TITLE
Fix: Recalculate tip when percentage changes

### DIFF
--- a/TipCalculaterbyZhao/ViewController.swift
+++ b/TipCalculaterbyZhao/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
+        tipControl.addTarget(self, action: "calculate:", forControlEvents: .ValueChanged)
     }
 
     override func didReceiveMemoryWarning() {

--- a/TipCalculaterbyZhaoTests/TipCalculaterbyZhaoTests.swift
+++ b/TipCalculaterbyZhaoTests/TipCalculaterbyZhaoTests.swift
@@ -21,9 +21,27 @@ class TipCalculaterbyZhaoTests: XCTestCase {
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testTipControlHasTarget() {
+        let viewController = ViewController()
+
+        let tipControl = UISegmentedControl(items: ["18%", "20%", "25%"])
+        // We need to have a dummy billField, otherwise the app will crash when trying to read `billField.text!`
+        let billField = UITextField()
+        viewController.tipControl = tipControl
+        viewController.billField = billField
+
+        // We need to instantiate the labels as well, otherwise the app will crash
+        viewController.tipLabel = UILabel()
+        viewController.totalLabel = UILabel()
+
+
+        viewController.viewDidLoad()
+
+        let actions = viewController.tipControl.actionsForTarget(viewController, forControlEvent: .ValueChanged)
+        XCTAssertNotNil(actions)
+        if let actions = actions {
+            XCTAssertTrue(actions.contains("calculate:"))
+        }
     }
     
     func testPerformanceExample() {


### PR DESCRIPTION
The tip and total amounts were not being recalculated when the user changed the tip percentage using the segmented control. This was because the `calculate` function was not being called on the `ValueChanged` event of the `UISegmentedControl`.

This commit fixes the bug by adding a target to the `tipControl` in `viewDidLoad` to call the `calculate` function whenever the selected segment changes.

A new unit test has been added to verify that the target and action are correctly set up on the `tipControl`.